### PR TITLE
Add authentication with jsonwebtoken and cookies

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,10 +1,20 @@
 import React from "react";
 import GlobalStyles from "./GlobalStyles";
-import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  Link,
+  Redirect,
+} from "react-router-dom";
 import Apps from "./pages/Apps";
 import Logs from "./pages/Logs";
+import useCookie from "./hooks/useCookie";
+import Login from "./pages/Login";
 
 function App() {
+  const [authToken] = useCookie("authToken");
+
   return (
     <div>
       <GlobalStyles />
@@ -20,6 +30,9 @@ function App() {
           </ul>
         </nav>
         <Switch>
+          <Route path="/login">
+            <Login />
+          </Route>
           <Route path="/apps">
             <Apps />
           </Route>
@@ -27,6 +40,7 @@ function App() {
             <Logs />
           </Route>
         </Switch>
+        {!authToken && <Redirect to="/login" />}
       </Router>
     </div>
   );

--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -1,0 +1,12 @@
+export const login = async (credentials) => {
+  const response = await fetch("/api/login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(credentials),
+  });
+
+  const account = await response.json();
+  return account;
+};

--- a/client/src/hooks/useCookie.js
+++ b/client/src/hooks/useCookie.js
@@ -1,0 +1,23 @@
+import { useState, useCallback } from "react";
+import Cookies from "js-cookie";
+
+const useCookie = (cookieName) => {
+  const [value, setValue] = useState(() => Cookies.get(cookieName) || null);
+
+  const setCookie = useCallback(
+    (newValue, options) => {
+      Cookies.set(cookieName, newValue, options);
+      setValue(newValue);
+    },
+    [cookieName]
+  );
+
+  const removeCookie = useCallback(() => {
+    Cookies.remove(cookieName);
+    setValue(null);
+  }, [cookieName]);
+
+  return [value, setCookie, removeCookie];
+};
+
+export default useCookie;

--- a/client/src/pages/Login/Login.js
+++ b/client/src/pages/Login/Login.js
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
+import { login } from "../../api/auth";
+
+const Login = () => {
+  const [email, setEmail] = useState("");
+  const history = useHistory();
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    await login({ email });
+    history.push("/");
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="email"
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+        placeholder="Enter email"
+      />
+      <button>Login</button>
+    </form>
+  );
+};
+
+export default Login;

--- a/client/src/pages/Login/index.js
+++ b/client/src/pages/Login/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Login";

--- a/lib/authRouter.js
+++ b/lib/authRouter.js
@@ -1,0 +1,55 @@
+const express = require("express");
+const jwt = require("jsonwebtoken");
+
+const { getCollection } = require("./db");
+
+const authRouter = express.Router();
+
+const ONE_MONTH_IN_SECONDS = 30 * 24 * 60 * 60;
+authRouter.post("/login", async (request, response) => {
+  try {
+    const { email } = request.body;
+
+    const account = await getCollection("accounts").findOne({ email });
+
+    if (!account) {
+      return response.status(404).end("Account not found");
+    }
+    const authToken = jwt.sign({ email }, process.env.JWT_SECRET, {
+      expiresIn: ONE_MONTH_IN_SECONDS,
+    });
+
+    response.setHeader(
+      "Set-Cookie",
+      `authToken=${authToken};path=/;Max-Age=${ONE_MONTH_IN_SECONDS}`
+    );
+    response.json(account);
+  } catch (error) {
+    console.error(error);
+    response.status(500).send("Internal server error");
+  }
+});
+
+authRouter.post("/register", async (request, response) => {
+  try {
+    const { email } = request.body;
+
+    const existingAccount = await getCollection("accounts").findOne({ email });
+
+    if (existingAccount) {
+      return response.status(409).end("Account already exists");
+    }
+
+    const inserted = await getCollection("accounts").insertOne({ email });
+    if (!inserted.result.ok) {
+      return response.status(500).end("Can not register account");
+    }
+
+    const account = inserted.ops[0];
+    response.json(account);
+  } catch (error) {
+    console.error(error);
+    response.status(500).send("Internal server error");
+  }
+});
+module.exports = authRouter;

--- a/lib/logsRouter.js
+++ b/lib/logsRouter.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const jwt = require("jsonwebtoken");
 const { getCollection } = require("./db");
 
 const logsRouter = express.Router();
@@ -6,6 +7,7 @@ const logsRouter = express.Router();
 logsRouter.post("/", async (request, response) => {
   try {
     const log = request.body;
+
     await getCollection("logs").insertOne(log);
     response.json("😁");
   } catch (error) {
@@ -17,6 +19,18 @@ logsRouter.post("/", async (request, response) => {
 logsRouter.get("/", async (request, response) => {
   try {
     const { level } = request.query;
+    const { authToken } = request.cookies;
+
+    if (!authToken) {
+      return response.status(401).end("Unauthorized");
+    }
+
+    const { email } = jwt.verify(authToken, process.env.JWT_SECRET);
+    const account = await getCollection("accounts").findOne({ email });
+    if (!account) {
+      return response.status(401).end("Unauthorized");
+    }
+
     let query = null;
     if (!level) {
       query = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -718,6 +718,11 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
       "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -1292,6 +1297,14 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2655,6 +2668,30 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsx-ast-utils": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
@@ -2663,6 +2700,25 @@
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keyv": {
@@ -2811,6 +2867,41 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -3028,8 +3119,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1122,6 +1122,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,6 +2616,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/lmachens/cra-with-api#readme",
   "dependencies": {
     "body-parser": "^1.19.0",
+    "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "js-cookie": "^2.2.1",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.6.1"
   },

--- a/server.js
+++ b/server.js
@@ -2,15 +2,17 @@ require("dotenv").config();
 
 const express = require("express");
 const path = require("path");
+const bodyParser = require("body-parser");
+const cookieParser = require("cookie-parser");
 const { connectDB } = require("./lib/db");
 const logsRouter = require("./lib/logsRouter");
-const bodyParser = require("body-parser");
 const authRouter = require("./lib/authRouter");
 
 const app = express();
 const port = process.env.PORT || 3001;
 
 app.use(bodyParser.json());
+app.use(cookieParser());
 
 // Serve any static files
 app.use(express.static(path.join(__dirname, "client/build")));

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const path = require("path");
 const { connectDB } = require("./lib/db");
 const logsRouter = require("./lib/logsRouter");
 const bodyParser = require("body-parser");
+const authRouter = require("./lib/authRouter");
 
 const app = express();
 const port = process.env.PORT || 3001;
@@ -19,6 +20,7 @@ app.use(
 );
 
 app.use("/api/logs", logsRouter);
+app.use("/api", authRouter);
 
 // Handle React routing, return all requests to React app
 app.get("*", (req, res) => {


### PR DESCRIPTION
Resolve #10 

There is no password required for authentication right now. I plan to allow access by email only and add email verification in the future.
New routes:
`/api/register` will create a new account based on an email.
`/api/login` will login by email and sends a cookie to the client (jsonwebtoken) to verify the access in upcoming requests.
`/api/logs` GET checks for a valid jsonwebtoken in the cookies before allowing access to the logs.
The POST route is not effected right now.

UI is very basic. Next, I'll focus on the UI.